### PR TITLE
8 3rd of <input> element overflow in <form> element

### DIFF
--- a/band-template/src/components/_footer.scss
+++ b/band-template/src/components/_footer.scss
@@ -64,11 +64,12 @@
       text-align: right;
 
       input {
+        width: calc(50% - 10px);
         @extend .lato_15px;
         padding: 12px 8px;
 
         &:nth-child(2) {
-          margin-left: 15px;
+          margin-left: 20px;
         }
 
         &:nth-child(3) {


### PR DESCRIPTION
For <input> elements ;
+ `width: calc(50% - 10px);` declaration added.
`margin-left` property value changed 15px to 20px

